### PR TITLE
Updated release-proguard.txt to fix #159

### DIFF
--- a/roundedimageview/release-proguard.cfg
+++ b/roundedimageview/release-proguard.cfg
@@ -1,2 +1,5 @@
 # Proguard configuration.
 -dontwarn com.squareup.okhttp.**
+
+# References to Picasso are okay if the consuming app doesn't use it
+-dontwarn com.squareup.picasso.Transformation


### PR DESCRIPTION
Fix for #159 because references to Picasso are okay if the consuming app doesn't use it
